### PR TITLE
LIBHYDRA-577. Combined the catalog and static_pages solr_connection_error methods.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,11 @@ class ApplicationController < ActionController::Base
   layout 'blacklight'
   skip_after_action :discard_flash_if_xhr
 
+  def solr_connection_error(err)
+    Rails.logger.error(err.message)
+    flash[:error] = I18n.t(:solr_is_down)
+  end
+
   # Causes a "404 - Not Found" error page to be displayed.
   def not_found
     render file: Rails.root.join('public', '404.html'), status: :not_found, layout: false

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,8 +4,8 @@ class CatalogController < ApplicationController
   include Blacklight::Catalog
   before_action :make_current_query_accessible, only: %i[show index] # rubocop:disable Rails/LexicallyScopedActionFilter
 
-  rescue_from Blacklight::Exceptions::ECONNREFUSED, with: :solr_connection_error
-  rescue_from Blacklight::Exceptions::InvalidRequest, with: :solr_connection_error
+  rescue_from Blacklight::Exceptions::ECONNREFUSED, with: :goto_about_page
+  rescue_from Blacklight::Exceptions::InvalidRequest, with: :goto_about_page
 
   configure_blacklight do |config| # rubocop:disable Metrics/BlockLength
     ## Class for sending and receiving requests from a search index
@@ -214,10 +214,8 @@ class CatalogController < ApplicationController
   end
 
   private
-
-    def solr_connection_error(err)
-      Rails.logger.error(err.message)
-      flash[:error] = I18n.t(:solr_is_down)
+    def goto_about_page(err)
+      solr_connection_error(err)
       redirect_to(about_url)
     end
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -10,11 +10,4 @@ class StaticPagesController < ApplicationController
   rescue SocketError => e
     solr_connection_error(e)
   end
-
-  private
-
-    def solr_connection_error(err)
-      Rails.logger.error(err.message)
-      flash[:error] = I18n.t(:solr_is_down)
-    end
 end


### PR DESCRIPTION
- put the common code into the application controller (logging and setting the flash message)
- replaced the Solr error handler in the catalog_controller with goto_about_page, which calls solr_connection_error then does the redirect

https://umd-dit.atlassian.net/browse/LIBHYDRA-577