### PR TITLE
LIBFCREPO-1520. Additional style adjustments.

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -8,10 +8,10 @@ body {
     margin: 0;
 }
 
-#viewport {
+#main-container {
     min-height: 100%;
     position: relative;
-    padding-bottom: $footer-height;
+    padding-bottom: $footer-content-height + (2 * $footer-padding-height) !important;
 }
 
 footer {

--- a/app/assets/stylesheets/_sidebar.scss
+++ b/app/assets/stylesheets/_sidebar.scss
@@ -1,0 +1,6 @@
+.page-sidebar .card {
+    margin-bottom: 1rem;
+}
+.card .nav {
+    margin: 1rem;
+}

--- a/app/assets/stylesheets/_umd_classes.scss
+++ b/app/assets/stylesheets/_umd_classes.scss
@@ -26,3 +26,7 @@
 .umd-table th {
   background:#eee;
 }
+
+.publish-controls {
+  display: inline;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import "umd_classes";
 @import "job_states";
 @import "footer";
+@import "sidebar";
 
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -19,18 +19,16 @@
   .select{|member| member['component'] == 'Page'}
   .sort{|a,b| a['page_number'] <=> b['page_number'] } %>
 <% unless pages.empty? %>
-  <div class="panel panel-default">
-    <div class="panel-heading">Select Page for More Options</div>
-    <div class="panel-body">
-      <ul class="nav">
-        <% pages.first(8).each do |v| %>
-          <li><%= link_to v['display_title'], solr_document_path(v['id']) %></li>
-        <% end %>
-        <% if pages.length > 8 %>
-          <li><a href="#pages" data-toggle="modal">more »</a></li>
-        <% end %>
-      </ul>
-    </div>
+  <div class="card">
+    <div class="card-header">Select Page for More Options</div>
+    <ul class="nav">
+      <% pages.first(8).each do |v| %>
+        <li><%= link_to v['display_title'], solr_document_path(v['id']) %></li>
+      <% end %>
+      <% if pages.length > 8 %>
+        <li><a href="#pages" data-toggle="modal">more »</a></li>
+      <% end %>
+    </ul>
   </div>
   <% if pages.length > 8 %>
     <div class="modal" id="pages" role="dialog">
@@ -55,15 +53,13 @@
 
 <% files = presenter.field_value(presenter.configuration.show_fields['pcdm_files']) %>
 <% unless files.empty? %>
-  <div class="panel panel-default">
-    <div class="panel-heading">Select File for Download Options</div>
-    <div class="panel-body">
-      <ul class="nav">
-        <% files.each do |v| %>
-          <li><%= link_to(v['display_title'].present? ? v['display_title'] : v['id'], solr_document_path(v['id'])) %></li>
-        <% end %>
-      </ul>
-    </div>
+  <div class="card">
+    <div class="card-header">Select File for Download Options</div>
+    <ul class="nav">
+      <% files.each do |v| %>
+        <li><%= link_to(v['display_title'].present? ? v['display_title'] : v['id'], solr_document_path(v['id'])) %></li>
+      <% end %>
+    </ul>
   </div>
 <% end %>
 <%# End UMD Customization %>

--- a/app/views/mirador/_show.html.erb
+++ b/app/views/mirador/_show.html.erb
@@ -3,7 +3,7 @@
     <a href="#metadata">Go to Metadata</a>
     <% if @show_edit_metadata %>
       &nbsp;
-      <a href="<%= resource_edit_url(id: @document.id) %>" class="btn btn-default">Edit Metadata</a>
+      <a href="<%= resource_edit_url(id: @document.id) %>" class="btn btn-secondary">Edit Metadata</a>
 
       <%= form_with url: update_resource_url(@document.id), method: :post, data: {remote: false}, class: 'publish-controls' do |form| %>
         <% if @published %>


### PR DESCRIPTION
- change class names from "panel" to "card" for the sidebar elements for linking to pages and files
- force the "Publish"/"Unpublish" button at the top of the details page to display inline with the metadata links
- adjusted the main container's padding so that the bottom portion of a long page it is not covered up by the footer
- changed the "Edit Metadata" button class to secoondary from default

https://umd-dit.atlassian.net/browse/LIBFCREPO-1520