### PR TITLE
LIBFCREPO-1693. Use the parent query parser for the location and subject searches.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -291,14 +291,21 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
       field.solr_parameters = { df: 'identifier', defType: 'edismax', 'q:alt': '*:*' }
     end
 
-    config.add_search_field('subject__facet') do |field|
+    # For the subject and location searches, use the parent query parser to return
+    # the parent documents of the documents that match the given query.
+    # See also the Solr documentation here:
+    # https://solr.apache.org/guide/solr/9_6/query-guide/searching-nested-documents.html#parent-query-parser
+
+    config.add_search_field('subject') do |field|
       field.label = 'Subject'
-      field.solr_parameters = { df: 'subject__facet', defType: 'edismax', 'q:alt': '*:*' }
+      field.solr_parameters = { df: 'subject__label__txt' }
+      field.solr_local_parameters = { type: 'parent', which: '*:* -_nest_path_:*' }
     end
 
-    config.add_search_field('location__facet') do |field|
+    config.add_search_field('location') do |field|
       field.label = 'Location'
-      field.solr_parameters = { df: 'location__facet', defType: 'edismax', 'q:alt': '*:*' }
+      field.solr_parameters = { df: 'place__label__txt' }
+      field.solr_local_parameters = { type: 'parent', which: '*:* -_nest_path_:*' }
     end
 
     # Now we see how to over-ride Solr request handler defaults, in this


### PR DESCRIPTION
The parent query parser allows us to search the child document fields `subject__label__txt` and `place__label__txt` but return the parent documents of any results found.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1693