### PR TITLE
LIBFCREPO-1712. Only display IIIF viewer for Item and Issue resources.

### DIFF
--- a/app/assets/stylesheets/_umd_classes.scss
+++ b/app/assets/stylesheets/_umd_classes.scss
@@ -38,3 +38,12 @@
 .hl {
   background-color: rgba(255, 255, 0, .25);
 }
+
+.sidebar-list {
+  list-style-type: none;
+  padding-top: 1em;
+  padding-left: 1em;
+  max-height: 200px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}

--- a/app/components/archelon_sidebar_component.html.erb
+++ b/app/components/archelon_sidebar_component.html.erb
@@ -10,25 +10,14 @@
   <% pages = document.key?(:page_label_sequence__txts) && document.key?(:page_uri_sequence__uris) ?
       document[:page_label_sequence__txts].zip(document[:page_uri_sequence__uris]) : [] %>
   <div class="card">
-    <div class="card-header"> Select Page(s) for More Options </div>
+    <div class="card-header"> Select Page to Access Files</div>
     <% if pages.nil? %>
       <ul class="nav">
-        <li> No File Found </li>
+        <li> No Pages Found </li>
       </ul>
-    <% elsif pages.length < 8 %>
-      &nbsp;
-      <nav>
-        <ul style="list-style-type: none; height: <% 24 * pages.length %>px">
-          <% pages.each do |page| %>
-            <li>
-                <%= link_to page[0], solr_document_path(page[1]) %>
-            </li>
-          <% end %>
-        </ul>
-      </nav>
     <% else %>
       <nav>
-        <ul style="list-style-type: none; height: 200px; overflow: hidden; overflow-y: scroll;">
+        <ul class="sidebar-list">
           <% pages.each do |page| %>
             <li>
                 <%= link_to page[0], solr_document_path(page[1]) %>
@@ -44,22 +33,14 @@
 <% if model == 'Page' || model != 'File' %>
   <% files = model == 'Page' ? document[:page__has_file] : document[:object__has_file] %>
   <div class="card">
-    <div class="card-header"> Select File(s) for Download Options </div>
+    <div class="card-header"> Select File for Download Options </div>
       <% if files.nil? %>
         <ul class="nav">
-          <li> No File Found </li>
-        </ul>
-      <% elsif files.length < 8 %>
-        <ul class="nav">
-          <% files.each do |file| %>
-            <li>
-                <%= link_to file['file__title__txt'], solr_document_path(file[:id]) %>
-            </li>
-          <% end %>
+          <li> No Files Found </li>
         </ul>
       <% else %>
         <nav>
-          <ul style="list-style-type: none; height: 200px; overflow: hidden; overflow-y: scroll;">
+          <ul class="sidebar-list">
             <% files.each do |file| %>
               <li>
                   <%= link_to file['file__title__txt'], solr_document_path(file[:id]) %>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -394,17 +394,6 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
 
   def show
     super
-
-    @id = params[:id]
-    @displayable = mirador_displayable?(@document)
-
-    @published = @document[:is_published]
-    @show_edit_metadata = CatalogController.show_edit_metadata?(@document[:content_model_name__str])
-  end
-
-  def self.show_edit_metadata?(model)
-    editable_types = %w[Item Issue]
-    editable_types.include?(model)
   end
 
   private
@@ -412,10 +401,6 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     def clear_search_session
       params.delete(:search_field)
       redirect_to action: 'index'
-    end
-
-    def mirador_displayable?(document)
-      %w[Item Issue Page].include?(document[:content_model_name__str])
     end
 
     def goto_about_page(err)

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -16,16 +16,7 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   use_extension(Blacklight::Document::DublinCore)
 
   def iiif_manifest_uri
-    model = fetch('content_model_name__str')
-    querier = Blacklight::Solr::Repository.new(Blacklight::Configuration.new)
-
-    if model == 'Page'
-      object = querier.search(q: "id: \"#{ fetch('page__member_of__uri') }\"").response['docs'][0]
-
-      object['iiif_manifest__uri']
-    else
-      fetch('iiif_manifest__uri')
-    end
+    fetch('iiif_manifest__uri')
   end
 
   def creator_language_badge
@@ -142,6 +133,22 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
   def extracted_text
     text_values = response.dig('highlighting', id, 'extracted_text__dps_txt') || []
     text_values.map { |value| value.gsub(/\|n=\d+&xywh=\d+,\d+,\d+,\d+/, '') }
+  end
+
+  def content_model
+    fetch('content_model_name__str')
+  end
+
+  def displayable?
+    %w[Item Issue].include? content_model
+  end
+
+  def editable?
+    %w[Item Issue].include? content_model
+  end
+
+  def published?
+    fetch('is_published')
   end
 
   private

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -6,25 +6,27 @@
 <%= render (document_component).new(document_component.collection_parameter => document_presenter(@document), component: :div, show: true, partials: blacklight_config.view_config(:show).partials) do |component| %>
 
   <%# UMD Customization %>
-  <% if @displayable %>
+  <% if @document.displayable? or @document.editable? %>
     <div class="skip-link">
-      <% if @show_edit_metadata %>
+      <% if @document.editable? %>
         <%= link_to "Edit Metadata",
                     resource_edit_url(id: @document.id),
                     class: "btn btn-primary",
                     data: { turbo: false } %>
 
         <%= form_with url: update_resource_url(@document.id), method: :post, data: {remote: false}, class: 'publish-controls' do |form| %>
-          <% if @published %>
+          <% if @document.published? %>
             <%= form.submit "Unpublish", name: 'command', class: 'btn btn-primary' %>
           <% else %>
             <%= form.submit "Publish", name: 'command', class: 'btn btn-primary' %>
           <% end %>
         <% end %>
       <% end %>
-    </div>
-    <div class="image-viewer intrinsic-container ratio-4x3">
-      <iframe src="<%= iiif_viewer_url(@document.iiif_manifest_uri, @current_query) %>" allowfullscreen></iframe>
+      <% if @document.displayable? %>
+        <div class="image-viewer intrinsic-container ratio-4x3">
+          <iframe src="<%= iiif_viewer_url(@document.iiif_manifest_uri, @current_query) %>" allowfullscreen></iframe>
+        </div>
+      <% end %>
     </div>
   <% end %>
   <%# End UMD Customization %>

--- a/test/controllers/catalog_controller_test.rb
+++ b/test/controllers/catalog_controller_test.rb
@@ -28,17 +28,6 @@ class CatalogControllerTest < ActionController::TestCase
     end
   end
 
-  test 'show_edit_metadata should be "true" for top-level components' do
-    assert CatalogController.show_edit_metadata?('Item')
-    assert CatalogController.show_edit_metadata?('Issue')
-  end
-
-  test 'show_edit_metadata? should be "false" for non-top-level components' do
-    assert_not CatalogController.show_edit_metadata?('Article')
-    assert_not CatalogController.show_edit_metadata?('Page')
-    assert_not CatalogController.show_edit_metadata?('File')
-  end
-
   test 'should redirect to item detail page on identifier search with a single match' do
     # Inject the stubbed search_results_mock into the controller
     # UMD Blacklight 8 Fix

--- a/test/models/solr_document_test.rb
+++ b/test/models/solr_document_test.rb
@@ -60,4 +60,32 @@ class SolrDocumentTest < ActiveSupport::TestCase
       assert_equal expected, solr_doc.members_anchor, "'#{test_value} did not return '#{expected}'"
     end
   end
+
+  test 'displayable? should be "true" for top-level components' do
+    %w[Item Issue].each do |content_model_name|
+      doc = SolrDocument.new({ content_model_name__str: content_model_name })
+      assert doc.displayable?
+    end
+  end
+
+  test 'displayable? should be "false" for non-top-level components' do
+    %w[Article Page File].each do |content_model_name|
+      doc = SolrDocument.new({ content_model_name__str: content_model_name })
+      assert_not doc.displayable?
+    end
+  end
+
+  test 'editable? should be "true" for top-level components' do
+    %w[Item Issue].each do |content_model_name|
+      doc = SolrDocument.new({ content_model_name__str: content_model_name })
+      assert doc.editable?
+    end
+  end
+
+  test 'editable? should be "false" for non-top-level components' do
+    %w[Article Page File].each do |content_model_name|
+      doc = SolrDocument.new({ content_model_name__str: content_model_name })
+      assert_not doc.editable?
+    end
+  end
 end


### PR DESCRIPTION
- moved the checks for displayable, editable, and publication status into the SolrDocument as predicate methods
- changed the sidebar heading to "Select Page to Access Files"
- simplified the CSS for the sidebar page and file lists, and put into the external CSS file

https://umd-dit.atlassian.net/browse/LIBFCREPO-1712