### PR TITLE
LIBFCREPO-1816. Code review of metadata highlighting.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -206,11 +206,11 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     # config.add_index_field 'lc_callnum_ssim', label: 'Call number'
     config.add_index_field 'extracted_text__dps_txt', label: 'Text Content', accessor: :extracted_text, component: HighlightedMetadataComponent
     config.add_index_field 'object__date__edtf', label: 'Date'
-    config.add_index_field 'object__description__txt', label: 'Description', accessor: :description_highlight, component: HighlightedMetadataComponent
+    config.add_index_field 'object__description__txt', label: 'Description', accessor: :highlighted_values, component: HighlightedMetadataComponent
     config.add_index_field 'resource_type__facet', label: 'Resource Type'
     config.add_index_field 'page_count__int', label: 'Number of Pages'
-    config.add_index_field 'object__archival_collection__label__txt', label: 'Archival Collection', accessor: :archival_collection_highlight, component: HighlightedMetadataComponent
-    config.add_index_field 'creator__facet', label: 'Creator', accessor: :creator_highlight, component: HighlightedMetadataComponent
+    config.add_index_field 'object__archival_collection__label__txt', label: 'Archival Collection', accessor: :highlighted_values, component: HighlightedMetadataComponent
+    config.add_index_field 'creator__facet', label: 'Creator', accessor: :highlighted_values, component: HighlightedMetadataComponent
 
     # Have BL send the most basic highlighting parameters for you
     config.add_field_configuration_to_solr_request!

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -318,8 +318,10 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
         hl: true,
         'hl.fl': 'extracted_text__dps_txt object__title__display creator__facet ' \
                  'object__archival_collection__label__txt object__description__txt',
-        'hl.snippets': 5,
-        'hl.fragsize': 50,
+        'hl.snippets': 1,
+        'hl.fragsize': 0,
+        'f.extracted_text__dps_txt.hl.snippets': 5,
+        'f.extracted_text__dps_txt.hl.fragsize': 50,
         'hl.maxAnalyzedChars': 1_000_000,
         'hl.tag.pre': SolrDocument::HL_START_CHAR,
         'hl.tag.post': SolrDocument::HL_END_CHAR

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -107,34 +107,6 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
     hightlight_values(highlighted_values)
   end
 
-  def title_highlight
-    highlighted_values = response.dig('highlighting', id, 'object__title__display') || []
-    return self['object__title__display'] if highlighted_values.empty?
-
-    hightlight_values(highlighted_values)
-  end
-
-  def creator_highlight
-    highlighted_values = response.dig('highlighting', id, 'creator__facet') || []
-    return self['creator__facet'] if highlighted_values.empty?
-
-    hightlight_values(highlighted_values)
-  end
-
-  def description_highlight
-    highlighted_values = response.dig('highlighting', id, 'object__description__txt') || []
-    return self['object__description__txt'] if highlighted_values.empty?
-
-    hightlight_values(highlighted_values)
-  end
-
-  def archival_collection_highlight
-    highlighted_values = response.dig('highlighting', id, 'object__archival_collection__label__txt') || []
-    return self['object__archival_collection__label__txt'] if highlighted_values.empty?
-
-    hightlight_values(highlighted_values)
-  end
-
   def content_model
     fetch('content_model_name__str')
   end
@@ -166,6 +138,16 @@ class SolrDocument # rubocop:disable Metrics/ClassLength
       tagged_names = agent[:agent__label__display].map { |name| format_with_language_tag(name) }
       safe_join(tagged_names, ' | ')
     end
+  end
+
+  # Can be used as an accessor in the Catalog Controller
+  def highlighted_values(field_name)
+    return unless has? field_name
+
+    highlighted_values = response.dig('highlighting', id, field_name) || []
+    return fetch(field_name) if highlighted_values.empty?
+
+    hightlight_values(highlighted_values)
   end
 
   private


### PR DESCRIPTION
A couple suggested improvements:

* use a single `highlighted_values` accessor in the `SolrDocument`
* adjust the highlighting fragsize and snippets count to show the full metadata fields, but only the relavent snippets of the full text

https://umd-dit.atlassian.net/browse/LIBFCREPO-1816